### PR TITLE
Fix incorrect nightwatch server URL along with incorrect CSS selectors for test cases

### DIFF
--- a/test/e2e/nightwatch.conf.js
+++ b/test/e2e/nightwatch.conf.js
@@ -29,7 +29,7 @@ module.exports = {
         path: 'test/e2e/reports/screenshots'
       },
       globals: {
-        devServerURL: `http://${config.dev.host}: ${process.env.PORT || config.dev.port}`
+        devServerURL: `http://${process.env.HOST || config.dev.host}:${process.env.PORT || config.dev.port}`
       }
     },
 

--- a/test/e2e/specs/test.js
+++ b/test/e2e/specs/test.js
@@ -45,10 +45,10 @@ module.exports = {
     browser
       .click('#app > div > aside > ul > li:nth-child(2) > a > div.list__tile__content > div')
       .waitForElementVisible('body', 5000)
-      .expect.element('#app > div.application--wrap > div > main > div.container.fluid.fill-height > div > div > div.layout.row.wrap > div:nth-child(6)').to.be.present.after(100)
+      .expect.element('#app > div.application--wrap > main > div > div.container.fluid.fill-height > div > div > div.layout.row.wrap > div:nth-child(6)').to.be.present.after(100)
 
     browser
-      .expect.element('#app > div.application--wrap > div > main > div.container.fluid.fill-height > div > div > div.layout.row.wrap > div:nth-child(7)').to.not.be.present.after(100)
+      .expect.element('#app > div.application--wrap > main > div > div.container.fluid.fill-height > div > div > div.layout.row.wrap > div:nth-child(7)').to.not.be.present.after(100)
   },
 
   'test text field': function (browser) {

--- a/test/e2e/specs/test.js
+++ b/test/e2e/specs/test.js
@@ -1,7 +1,7 @@
 // For authoring Nightwatch tests, see
 // http://nightwatchjs.org/guide#usage
 
-var devServer
+let devServer
 
 module.exports = {
   before: function (browser) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix incorrect nightwatch server URL along with incorrect CSS selectors for test cases

## Description
<!--- Describe your changes in detail -->
* Fixed nightwatch server url's format 
* Correct css selector for 2 test cases 
* Replace var declaration with let 

## Related Issue or Trello Card
<!--- This project only accepts pull requests related to open issues or Trello cards-->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue or the Trello Card here: -->
Issue: [Unable to run nightwatch tests cases against local server #18](https://github.com/371team4/371Team4/issues/18)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As a Developer/Jenkins, I need to be able to run test case against local server

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit test
- [x] NightWatch test
- [ ] Coverage testing
- [x] Manual testing

## Test Cases and test paths
<!--- What test steps did you take -->
Existing test cases were executed to test the changes 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
